### PR TITLE
Removed default folder icons

### DIFF
--- a/Flatron.sublime-theme
+++ b/Flatron.sublime-theme
@@ -623,6 +623,18 @@
         "parents": [{"class": "tree_row","attributes": ["selected"]}],
         "layer0.texture": "Theme - Flatron/Flatron/folder-open.png"
     },
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    },
 
 //
 // STANDARD TEXT BUTTONS


### PR DESCRIPTION
Sublime Text 3, build 3065 for me, has the default folder icons next to the custom Flatron ones (see below).
![screenshot 2014-10-07 11 22 50](https://cloud.githubusercontent.com/assets/2782749/4544776/ea2494f2-4e35-11e4-8160-288457e19f94.png)

This addition removes it, yielding the following result:
![screenshot 2014-10-07 10 37 23](https://cloud.githubusercontent.com/assets/2782749/4544629/d8cb9f4e-4e34-11e4-8e7d-3f2ae91b6860.png)
#16
