### PR TITLE
OS-Specific install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,11 @@ If you are using Will Bond's excellent Sublime Package Control, you can easily i
 
 #### Manual
   1. Download the [installer script](https://raw.githubusercontent.com/NoahBuscher/Flatron/master/install-sl3.sh) (cmd/ctrl+s)
-  2. Go to the directory where you saved the script in your terminal and run `sh insatll-sl3.sh`.
+  2. Go to the directory where you saved the script in your terminal and run `./install-sl3.sh`.
+  3. Do a happy dance! :tada:
+
+#### Manual, even easier (Do you trust us?)
+  1. Execute this command in your terminal:
+    - `curl -s https://raw.githubusercontent.com/NoahBuscher/Flatron/master/install-sl3.sh | bash`
+  2. Copy the settings provided to you by the installer into your User Preferences
   3. Do a happy dance! :tada:

--- a/README.md
+++ b/README.md
@@ -16,15 +16,26 @@ If you are using Will Bond's excellent Sublime Package Control, you can easily i
   2. Open your User Settings Preferences file `Sublime Text -> Preferences -> Settings - User`
   3. Add (or update) your theme entry to be `"theme": "Flatron.sublime-theme"`
   4. Change your color scheme to Flatron under `Preferences -> Color Scheme -> Theme - Flatron -> Flatron` in the menu; note this step is not required, but is highly reccommended
-  5. Restart Sublime Text and do a happy dance
+  5. Restart Sublime Text
+  6. Do a happy dance! :tada:
 
-#### Manual
-  1. Download the [installer script](https://raw.githubusercontent.com/NoahBuscher/Flatron/master/install-sl3.sh) (cmd/ctrl+s)
-  2. Go to the directory where you saved the script in your terminal and run `./install-sl3.sh`.
-  3. Do a happy dance! :tada:
-
-#### Manual, even easier (Do you trust us?)
+#### Auto-Installer (Mac)
+  > **Important Note:** If you are *not* on a Mac, the installer script won't work!
+  
   1. Execute this command in your terminal:
     - `curl -s https://raw.githubusercontent.com/NoahBuscher/Flatron/master/install-sl3.sh | bash`
   2. Copy the settings provided to you by the installer into your User Preferences
-  3. Do a happy dance! :tada:
+  3. Restart Sublime Text
+  4. Do a happy dance! :tada:
+
+
+#### Manual Installation (Windows and Linux)
+  1. Download the [latest release](https://github.com/Codingbean/Flatron/releases)
+  2. Unzip the files and rename the folder to `Theme - Flatron`; be sure to include the spaces
+  3. Find your Packages directory using the menu item `Preferences -> Browse Packages`
+  4. Copy the folder into your Sublime Text `Packages` directory
+  5. Open your User Settings Preferences file `Sublime Text -> Preferences -> Settings - User`
+  6. Add (or update) your theme entry to be `"theme": "Flatron.sublime-theme"`
+  7. Change your color scheme to Flatron under `Preferences -> Color Scheme -> Theme - Flatron -> Flatron` in the menu; note this step is not required, but is highly reccommended
+  8. Restart Sublime Text
+  9. Do a happy dance! :tada:


### PR DESCRIPTION
Because the installer is Mac OS X-specific, I felt compelled to update the readme to accommodate non-Mac users in the installation instructions. 

Additionally, I updated the Mac installation to retrieve the script via `curl` and pipe it straight to `bash`. No need to download it before running it! :)