### PR TITLE
Simple fix for selected quick panel label (row)

### DIFF
--- a/Flatron.sublime-theme
+++ b/Flatron.sublime-theme
@@ -722,7 +722,7 @@
         "class": "quick_panel_label",
         "fg": [167, 173, 186, 255],
         "match_fg": [192, 197, 206, 255],
-        "selected_fg": [192, 197, 206, 255],
+        "selected_fg": [255, 255, 255, 255],
         "selected_match_fg": [239, 241, 245, 255]
     },
     {


### PR DESCRIPTION
I cannot see which file is selected in the quick panel row (Ctrl+P) like I can in Definitions panel (Ctrl+R).

So I tried changing

```
{
        "class": "quick_panel_row",
        "attributes": ["selected"],
        "layer0.tint": [255, 40, 48]
    },
```

To

```
{
        "class": "quick_panel_row",
        "attributes": ["selected"],
        "layer0.tint": [255, 49, 60]
    },
```

But whatever I type there it does not work. I cannot find the documentation for sublime themes, so I changed this:

```
{
        "class": "quick_panel_label",
        "fg": [167, 173, 186, 255],
        "match_fg": [192, 197, 206, 255],
        "selected_fg": [192, 197, 206, 255],
        "selected_match_fg": [239, 241, 245, 255]
    },
```

to this:

```
"class": "quick_panel_label",
        "fg": [167, 173, 186, 255],
        "match_fg": [192, 197, 206, 255],
        "selected_fg": [255, 255, 255, 255],
        "selected_match_fg": [239, 241, 245, 255]
```

It is more visible now to see which file is currently selected when doing Ctrl+P. 

If you have a better solution I would be glad to see it.

Btw. This theme is awesome. I've fallen in love with it.
